### PR TITLE
Fix broken version metadata

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,16 +4,19 @@ rem -- get build datetime
 for /f "tokens=*" %%a in (
 'python -c "import datetime; print(datetime.datetime.now(datetime.UTC).strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ'))"'
 ) do (
-set BUILDDATE=%%a
+set BUILD_DATE=%%a
 )
 
 go generate ./...
 if errorlevel 1 exit 1
 
+set "CONFIG_PKG=github.com/pelicanplatform/pelican/config"
+set "LDFLAGS=-w -s -X %CONFIG_PKG%.version=%PKG_VERSION% -X %CONFIG_PKG%.commit=v%PKG_VERSION% -X %CONFIG_PKG%.date=%BUILD_DATE% -X %CONFIG_PKG%.builtBy=conda-forge"
+
 rem -- run the build
 go build ^
   -a ^
-  -ldflags "-w -s -X main.version=%PKG_VERSION% -X main.commit=v%PKG_VERSION% -X main.date=%BUILD_DATE% -X main.builtBy=conda-forge" ^
+  -ldflags "%LDFLAGS%" ^
   -tags forceposix ^
   -p "%CPU_COUNT%" ^
   -v ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,10 +5,21 @@ set -ex
 # dynamically generate content
 GOARCH="" GOOS="" go generate ./...
 
+# set variables for build
+CONFIG_PKG="github.com/pelicanplatform/pelican/config"
+LDFLAGS="
+  -s
+  -w
+  -X ${CONFIG_PKG}.version=${PKG_VERSION}
+  -X ${CONFIG_PKG}.commit=v${PKG_VERSION}
+  -X ${CONFIG_PKG}.date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  -X ${CONFIG_PKG}.builtBy=conda-forge
+"
+
 # build and install
 go build \
   -a \
-  -ldflags "-w -s -X main.version=${PKG_VERSION} -X main.commit=v${PKG_VERSION} -X main.date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") -X main.builtBy=conda-forge" \
+  -ldflags "${LDFLAGS}" \
   -tags forceposix \
   -p ${CPU_COUNT} \
   -v \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     fn: mathutil-LICENSE
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
 test:
   commands:
     - pelican --help
+    - pelican --version
     - pelican object copy --help
 
 about:


### PR DESCRIPTION
This MR fixes the `-ldflags` argument that is used to set metadata variables (for `pelican --version`).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
