### PR TITLE
Fix the version metadata again

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ set -ex
 GOARCH="" GOOS="" go generate ./...
 
 # set variables for build
-CONFIG_PKG="github.com/pelicanplatform/pelican/config"
+CONFIG_PKG="github.com/pelicanplatform/pelican/version"
 LDFLAGS="
   -s
   -w

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     fn: mathutil-LICENSE
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,6 +24,8 @@ test:
   commands:
     - pelican --help
     - pelican --version
+    # check that the metadata variables are set correctly
+    - "pelican --version | grep -q 'Version: {{ version }}'"  # [unix]
     - pelican object copy --help
 
 about:


### PR DESCRIPTION
This PR fixes the declaration of version/build metadata, and adds a test command to catch when this breaks in the future.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
